### PR TITLE
Fix leaguescontroller errors in league creator

### DIFF
--- a/app/controllers/leagues_controller.rb
+++ b/app/controllers/leagues_controller.rb
@@ -17,7 +17,7 @@ class LeaguesController < ApplicationController
       flash[:notice] = "League created!"
       redirect_to league_creator.league
     else
-      flash[:alert] = @league.errors.full_messages
+      flash[:alert] = league_creator.errors.join(", ")
       render :new
     end
   end

--- a/lib/league_creator.rb
+++ b/lib/league_creator.rb
@@ -1,5 +1,5 @@
 class LeagueCreator
-  attr_reader :league, :membership
+  attr_reader :league, :membership, :errors
 
   def initialize(params, user)
     @params = params
@@ -11,14 +11,14 @@ class LeagueCreator
 
   def save
     @league = create_league
-    @membership = create_membership
+    @membership = create_membership if errors.empty?
     return true if errors.empty?
     false
   end
 
   private
 
-  attr_reader :params, :user, :errors
+  attr_reader :params, :user
 
   def create_league
     league = League.new(params)


### PR DESCRIPTION
This was originally to create a game without season_id, but that apparently already exists. so instead, this is to fix errors in league_creator when a league with the same name already exists.